### PR TITLE
Catch exceptions thrown by client.refreshToken

### DIFF
--- a/lib/oauth2_helper.dart
+++ b/lib/oauth2_helper.dart
@@ -130,8 +130,12 @@ class OAuth2Helper {
   Future<AccessTokenResponse> refreshToken(String refreshToken) async {
     var tknResp;
 
-    tknResp = await client.refreshToken(refreshToken,
-        clientId: clientId, clientSecret: clientSecret);
+    try {
+      tknResp = await client.refreshToken(refreshToken,
+          clientId: clientId, clientSecret: clientSecret);
+    } catch (_) {
+      return await fetchToken();
+    }
 
     if (tknResp == null) {
       throw OAuth2Exception('Unexpected error');

--- a/lib/oauth2_helper.dart
+++ b/lib/oauth2_helper.dart
@@ -76,10 +76,10 @@ class OAuth2Helper {
     var tknResp = await getTokenFromStorage();
 
     if (tknResp != null) {
-      if (tknResp.refreshNeeded()) {
+      //if (tknResp.refreshNeeded()) {
         //The access token is expired
         tknResp = await refreshToken(tknResp.refreshToken);
-      }
+      //}
     } else {
       tknResp = await fetchToken();
     }

--- a/lib/oauth2_helper.dart
+++ b/lib/oauth2_helper.dart
@@ -76,10 +76,10 @@ class OAuth2Helper {
     var tknResp = await getTokenFromStorage();
 
     if (tknResp != null) {
-      //if (tknResp.refreshNeeded()) {
+      if (tknResp.refreshNeeded()) {
         //The access token is expired
         tknResp = await refreshToken(tknResp.refreshToken);
-      //}
+      }
     } else {
       tknResp = await fetchToken();
     }


### PR DESCRIPTION
I noticed that some APIs, such as the Dropbox API v2, may throw exceptions on requests to refresh tokens. The Dropbox API throws an exception when refreshing a token if the user has disconnected their app on Dropbox's connected apps page.

Therefore, to handle these exceptions, I surrounded the client.refreshToken function in a try block and called the fetchToken function in the catch block.