### PR TITLE
Handle provider errors when refreshing tokens

### DIFF
--- a/lib/oauth2_helper.dart
+++ b/lib/oauth2_helper.dart
@@ -88,6 +88,10 @@ class OAuth2Helper {
       tknResp = await fetchToken();
     }
 
+    if (tknResp != null && tknResp.httpStatusCode != 200) {
+      throw Exception('Provider error ${tknResp.httpStatusCode}: ${tknResp.error}: ${tknResp.errorDescription}');
+    }
+
     if (tknResp != null && !tknResp.isBearer()) {
       throw Exception('Only Bearer tokens are currently supported');
     }


### PR DESCRIPTION
A provider I'm implementing custom OAuth support for is returning a 400 when refreshing a token. For context, this is the full error body from the service:
```
AccessTokenResponse (HTTP 400 - invalid_grant The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.)

accessToken:null
error:"invalid_grant"
errorDescription:"The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization requ…"
errorUri:null
expirationDate:null
expiresIn:null
httpStatusCode:400
refreshToken:null
scope:null
tokenType:null
hashCode:723283890
runtimeType:Type (AccessTokenResponse)
```
However `oauth2_client` swallows this error and continues on as if the response was a success, eventually causing a hard-to-understand error later, when `tknResp.isBearer()` is called on a response that has no token in it:
```
NoSuchMethodError: The method 'toLowerCase' was called on null.
```
This branch adds an explicit check for an error response, and throws an exception with more helpful information if so.