### PR TITLE
null check for scope in AccessTokenResponse parsing

### DIFF
--- a/lib/access_token_response.dart
+++ b/lib/access_token_response.dart
@@ -74,8 +74,8 @@ class AccessTokenResponse extends OAuth2Response {
       Map respMap = jsonDecode(response.body);
       //From Section 4.2.2. (Access Token Response) of OAuth2 rfc, the "scope" parameter in the Access Token Response is
       //"OPTIONAL, if identical to the scope requested by the client; otherwise, REQUIRED."
-      if ((!respMap.containsKey('scope') || respMap['scope'].isEmpty) &&
-          requestedScopes != null) {
+      if ((!respMap.containsKey('scope') || respMap['scope'] == null
+          || respMap['scope'].isEmpty) && requestedScopes != null) {
         respMap['scope'] = requestedScopes;
       }
       respMap['http_status_code'] = response.statusCode;


### PR DESCRIPTION
This adds a fix for #55 by simply null checking 'scope' before calling `isEmpty`. 