### PR TITLE
make httpClient optional again

### DIFF
--- a/lib/oauth2_helper.dart
+++ b/lib/oauth2_helper.dart
@@ -255,6 +255,8 @@ class OAuth2Helper {
       {Map<String, String> headers,
       dynamic body,
       http.Client httpClient}) async {
+    httpClient ??= http.Client();
+
     headers ??= {};
 
     var sendRequest = (accessToken) async {


### PR DESCRIPTION
Matches the pre-1.7.0 behavior for post() and get().