### PR TITLE
Refactored to allow subclasses to implement custom handling of request/response for non-standard oauth2 servers.

### DIFF
--- a/lib/access_token_response.dart
+++ b/lib/access_token_response.dart
@@ -71,16 +71,9 @@ class AccessTokenResponse extends OAuth2Response {
     AccessTokenResponse resp;
 
     if (response.statusCode != 404) {
-      Map respMap = jsonDecode(response.body);
-      //From Section 4.2.2. (Access Token Response) of OAuth2 rfc, the "scope" parameter in the Access Token Response is
-      //"OPTIONAL, if identical to the scope requested by the client; otherwise, REQUIRED."
-      if ((!respMap.containsKey('scope') ||
-              respMap['scope'] == null ||
-              respMap['scope'].isEmpty) &&
-          requestedScopes != null) {
-        respMap['scope'] = requestedScopes;
-      }
-      respMap['http_status_code'] = response.statusCode;
+      Map respMap = decodeHttpResponse(response, requestedScopes: requestedScopes);
+
+      setHttpStatusCode(respMap, response);
 
       resp = AccessTokenResponse.fromMap(respMap);
     } else {
@@ -89,6 +82,27 @@ class AccessTokenResponse extends OAuth2Response {
     }
 
     return resp;
+  }
+
+  static Map<String, dynamic> decodeHttpResponse(http.Response response, {requestedScopes}) {
+    Map respMap = jsonDecode(response.body);
+    //From Section 4.2.2. (Access Token Response) of OAuth2 rfc, the "scope" parameter in the Access Token Response is
+    //"OPTIONAL, if identical to the scope requested by the client; otherwise, REQUIRED."
+    if ((!respMap.containsKey('scope') ||
+        respMap['scope'] == null ||
+        respMap['scope'].isEmpty) &&
+        requestedScopes != null) {
+      respMap['scope'] = requestedScopes;
+    }
+    return respMap;
+  }
+
+  static void setHttpStatusCode(Map<String, dynamic> respMap, http.Response response) {
+    respMap['http_status_code'] = response.statusCode;
+  }
+
+  static AccessTokenResponse constructTokenResponse(Map<String, dynamic> respMap) {
+    return AccessTokenResponse.fromMap(respMap);
   }
 
   @override

--- a/lib/oauth2_client.dart
+++ b/lib/oauth2_client.dart
@@ -223,8 +223,12 @@ class OAuth2Client {
         headers: _accessTokenRequestHeaders,
         httpClient: httpClient);
 
+    return constructAccessTokenResponse(response, requestedScopes: scopes);
+  }
+
+  AccessTokenResponse constructAccessTokenResponse(http.Response response, {requestedScopes}) {
     return AccessTokenResponse.fromHttpResponse(response,
-        requestedScopes: scopes);
+        requestedScopes: requestedScopes);
   }
 
   /// Refreshes an Access Token issuing a refresh_token grant to the OAuth2 server.
@@ -239,7 +243,7 @@ class OAuth2Client {
         params: params,
         httpClient: httpClient);
 
-    return AccessTokenResponse.fromHttpResponse(response);
+    return constructAccessTokenResponse(response);
   }
 
   /// Revokes both the Access and the Refresh tokens in the provided [tknResp]
@@ -290,7 +294,6 @@ class OAuth2Client {
       params['redirect_uri'] = redirectUri;
     }
 
-    if (scopes != null && scopes.isNotEmpty) params['scope'] = scopes;
 
     if (enableState && state != null && state.isNotEmpty) {
       params['state'] = state;
@@ -305,7 +308,13 @@ class OAuth2Client {
       params.addAll(customParams);
     }
 
+    handleScopes(params, scopes);
+
     return OAuth2Utils.addParamsToUrl(authorizeUrl, params);
+  }
+
+  void handleScopes(Map<String, dynamic> params, List<String> scopes) {
+    if (scopes != null && scopes.isNotEmpty) params['scope'] = scopes;
   }
 
   /// Returns the parameters needed for the authorization code request

--- a/lib/oauth2_client.dart
+++ b/lib/oauth2_client.dart
@@ -294,6 +294,7 @@ class OAuth2Client {
       params['redirect_uri'] = redirectUri;
     }
 
+    handleScopes(params, scopes);
 
     if (enableState && state != null && state.isNotEmpty) {
       params['state'] = state;
@@ -307,8 +308,6 @@ class OAuth2Client {
     if (customParams != null && customParams is Map) {
       params.addAll(customParams);
     }
-
-    handleScopes(params, scopes);
 
     return OAuth2Utils.addParamsToUrl(authorizeUrl, params);
   }

--- a/lib/src/token_storage.dart
+++ b/lib/src/token_storage.dart
@@ -45,10 +45,14 @@ class TokenStorage {
         return found;
       }, orElse: () => null);
 
-      if (tknMap != null) tknResp = AccessTokenResponse.fromMap(tknMap);
+      if (tknMap != null) tknResp = constructTokenResponse(tknMap);
     }
 
     return tknResp;
+  }
+  
+  AccessTokenResponse constructTokenResponse(tknMap) {
+    return AccessTokenResponse.fromMap(tknMap);
   }
 
   Future<void> addToken(AccessTokenResponse tknResp) async {


### PR DESCRIPTION

Some oauth servers do not fully implement the standard, or have additional requirements. Refactored AccessTokenResponse, OAuth2Client, and TokenStorage to allow subclass to implement those custom behaviors. In particular, these are the "non-standard" implementations:

Requires scopes to be a comma separated string, rather than a list of strings
Additional information in access token response, such as userid
HTTP response status code included in the body, while the response status code is set to 200 even with error
Response has an extra 'body' element, which contains the actual content that should be in the top level response.body
These are all idiosyncrasies from Withings oauth implementation. Primarily, a subclass of AccessTokenResponse is required to parse these implementation details. The changes in this PR refactors some of detailed parsing, etc code into their own methods so that subclasses can overwrite the standard based parsing implemented by the base classes in oauth2_client.