### PR TITLE
Added optional login hint parameter for OAuth2Helper constructor

### DIFF
--- a/lib/oauth2_client.dart
+++ b/lib/oauth2_client.dart
@@ -132,6 +132,7 @@ class OAuth2Client {
     Function? afterAuthorizationCodeCb,
     Map<String, dynamic>? authCodeParams,
     Map<String, dynamic>? accessTokenParams,
+	String? loginHint,
     httpClient,
     BaseWebAuth? webAuthClient,
   }) async {
@@ -152,7 +153,8 @@ class OAuth2Client {
         codeChallenge: codeChallenge,
         enableState: enableState,
         state: state,
-        customParams: authCodeParams);
+        customParams: authCodeParams,
+		loginHint: loginHint);
 
     if (authResp.isAccessGranted()) {
       if (afterAuthorizationCodeCb != null) afterAuthorizationCodeCb(authResp);
@@ -205,6 +207,7 @@ class OAuth2Client {
     String? state,
     Map<String, dynamic>? customParams,
     BaseWebAuth? webAuthClient,
+	String? loginHint
   }) async {
     webAuthClient ??= this.webAuthClient;
 
@@ -219,7 +222,8 @@ class OAuth2Client {
         enableState: enableState,
         state: state,
         codeChallenge: codeChallenge,
-        customParams: customParams);
+        customParams: customParams,
+		loginHint: loginHint);
 
     // Present the dialog to the user
     final result = await webAuthClient.authenticate(
@@ -309,7 +313,8 @@ class OAuth2Client {
       bool enableState = true,
       String? state,
       String? codeChallenge,
-      Map<String, dynamic>? customParams}) {
+      Map<String, dynamic>? customParams,
+	  String? loginHint}) {
     final params = <String, dynamic>{
       'response_type': responseType,
       'client_id': clientId
@@ -335,6 +340,10 @@ class OAuth2Client {
     if (customParams != null && customParams is Map) {
       params.addAll(customParams);
     }
+	
+	if (loginHint != null && loginHint.isNotEmpty) {
+	  params['login_hint'] = loginHint;
+	}
 
     return OAuth2Utils.addParamsToUrl(authorizeUrl, params);
   }

--- a/lib/oauth2_helper.dart
+++ b/lib/oauth2_helper.dart
@@ -26,6 +26,7 @@ class OAuth2Helper {
   List<String>? scopes;
   bool enablePKCE;
   bool enableState;
+  String? loginHint;
 
   Function? afterAuthorizationCodeCb;
 
@@ -42,7 +43,8 @@ class OAuth2Helper {
       tokenStorage,
       this.afterAuthorizationCodeCb,
       this.authCodeParams,
-      this.accessTokenParams}) {
+      this.accessTokenParams,
+	  this.loginHint}) {
     this.tokenStorage = tokenStorage ?? TokenStorage(client.tokenUrl);
   }
 
@@ -58,7 +60,8 @@ class OAuth2Helper {
       bool? enablePKCE,
       bool? enableState,
       Map<String, dynamic>? authCodeParams,
-      Map<String, dynamic>? accessTokenParams}) {
+      Map<String, dynamic>? accessTokenParams,
+	  String? loginHint}) {
     this.grantType = grantType;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
@@ -67,6 +70,7 @@ class OAuth2Helper {
     this.enableState = enableState ?? true;
     this.authCodeParams = authCodeParams;
     this.accessTokenParams = accessTokenParams;
+	this.loginHint = loginHint;
 
     _validateAuthorizationParams();
   }
@@ -120,7 +124,8 @@ class OAuth2Helper {
           enableState: enableState,
           authCodeParams: authCodeParams,
           accessTokenParams: accessTokenParams,
-          afterAuthorizationCodeCb: afterAuthorizationCodeCb);
+          afterAuthorizationCodeCb: afterAuthorizationCodeCb,
+		  loginHint: loginHint);
     } else if (grantType == CLIENT_CREDENTIALS) {
       tknResp = await client.getTokenWithClientCredentialsFlow(
           clientId: clientId,


### PR DESCRIPTION
I've only added the changes I needed for the Authorization Code grant to work using a Custom OAuth2Client and the OAuth2Helper. Additional development may be needed to support the Client Credentials grant.

The purpose for this feature is to allow a username field and login button to be displayed in the app.

Additionally, if your Authorization Server is setup in such a way, you could have it auto-route you to a particular Identity Provider based on the login_hint that was sent in the authorize request (e.g. user123@my-company.com could auto-route to My Company IdP)

Forgive me if I've done something wrong as this is my first pull request ever. Thanks