### PR TITLE
Uncomment Uri encoding of parameters

### DIFF
--- a/lib/src/oauth2_utils.dart
+++ b/lib/src/oauth2_utils.dart
@@ -30,8 +30,8 @@ class OAuth2Utils {
       } else {
         val = v.trim();
       }
-      // qsList.add(k + '=' + Uri.encodeComponent(val));
-      qsList.add(k + '=' + val);
+      qsList.add(k + '=' + Uri.encodeComponent(val));
+      // qsList.add(k + '=' + val);
     });
 
     return qsList.join('&');


### PR DESCRIPTION
Query string for initiating the access code retrieval was commented out. This results in inconsistent use of the parameters as they are plain values when getting the access code, but they are Uri encoded strings when the http client makes a post request to exchange the access code into an access token.