### PR TITLE
Fix 'null check operator used on a null'

### DIFF
--- a/lib/src/io_web_auth.dart
+++ b/lib/src/io_web_auth.dart
@@ -13,7 +13,7 @@ class IoWebAuth implements BaseWebAuth {
     return await FlutterWebAuth.authenticate(
       callbackUrlScheme: callbackUrlScheme,
       url: url,
-      preferEphemeral: opts!['preferEphemeral'] ?? false,
+      preferEphemeral: (opts?['preferEphemeral'] == true),
     );
   }
 }


### PR DESCRIPTION
It fixes #102.

I additionally added explicit check `== true` to deal with the fact that values of this map are of type `dynamic` and `authenticate` method expects `bool` as `preferEphemeral` parameter.