### PR TITLE
Support fetching new a new token when expired without a refresh token

### DIFF
--- a/lib/oauth2_helper.dart
+++ b/lib/oauth2_helper.dart
@@ -86,9 +86,14 @@ class OAuth2Helper {
     var tknResp = await getTokenFromStorage();
 
     if (tknResp != null) {
-      if (tknResp.refreshNeeded() && tknResp.refreshToken != null) {
+      if (tknResp.refreshNeeded()) {
         //The access token is expired
-        tknResp = await refreshToken(tknResp.refreshToken!);
+        if (tknResp.refreshToken != null) {
+          tknResp = await refreshToken(tknResp.refreshToken!);
+        } else {
+          //No refresh token, fetch a new token
+          tknResp = await fetchToken();
+        }
       }
     } else {
       tknResp = await fetchToken();


### PR DESCRIPTION
Currently if an access token expires, but no refresh token is available OAuth2Helper.getToken() just returns the expired token.

This pull request changes this behaviour to trigger call to getToken() instead.