### PR TITLE
Added customParams in authorizeUI for Implicit grant flow

### DIFF
--- a/lib/oauth2_helper.dart
+++ b/lib/oauth2_helper.dart
@@ -100,8 +100,7 @@ class OAuth2Helper {
     }
 
     if (!tknResp.isValid()) {
-      throw Exception(
-          'Provider error ${tknResp.httpStatusCode}: ${tknResp.error}: ${tknResp.errorDescription}');
+      throw Exception('Provider error ${tknResp.httpStatusCode}: ${tknResp.error}: ${tknResp.errorDescription}');
     }
 
     if (!tknResp.isBearer()) {
@@ -146,7 +145,8 @@ class OAuth2Helper {
           scopes: scopes,
           enableState: enableState,
           webAuthClient: webAuthClient,
-          webAuthOpts: webAuthOpts);
+          webAuthOpts: webAuthOpts,
+          customParams: authCodeParams);
     } else {
       tknResp = AccessTokenResponse.errorResponse();
     }
@@ -159,15 +159,12 @@ class OAuth2Helper {
   }
 
   /// Performs a refresh_token request using the [refreshToken].
-  Future<AccessTokenResponse> refreshToken(
-      AccessTokenResponse curTknResp) async {
+  Future<AccessTokenResponse> refreshToken(AccessTokenResponse curTknResp) async {
     var tknResp;
     var refreshToken = curTknResp.refreshToken!;
     try {
       tknResp = await client.refreshToken(refreshToken,
-          clientId: clientId,
-          clientSecret: clientSecret,
-          scopes: curTknResp.scope);
+          clientId: clientId, clientSecret: clientSecret, scopes: curTknResp.scope);
     } catch (_) {
       return await fetchToken();
     }
@@ -188,8 +185,7 @@ class OAuth2Helper {
         //Fetch another access token
         tknResp = await getToken();
       } else {
-        throw OAuth2Exception(tknResp.error,
-            errorDescription: tknResp.errorDescription);
+        throw OAuth2Exception(tknResp.error, errorDescription: tknResp.errorDescription);
       }
     }
 
@@ -204,10 +200,7 @@ class OAuth2Helper {
 
     if (tknResp != null) {
       await tokenStorage.deleteToken(scopes ?? []);
-      return await client.revokeToken(tknResp,
-          clientId: clientId,
-          clientSecret: clientSecret,
-          httpClient: httpClient);
+      return await client.revokeToken(tknResp, clientId: clientId, clientSecret: clientSecret, httpClient: httpClient);
     } else {
       return OAuth2Response();
     }
@@ -220,68 +213,49 @@ class OAuth2Helper {
   /// Performs a POST request to the specified [url], adding the authorization token.
   ///
   /// If no token already exists, or if it is expired, a new one is requested.
-  Future<http.Response> post(String url,
-      {Map<String, String>? headers,
-      dynamic body,
-      http.Client? httpClient}) async {
-    return _request('POST', url,
-        headers: headers, body: body, httpClient: httpClient);
+  Future<http.Response> post(String url, {Map<String, String>? headers, dynamic body, http.Client? httpClient}) async {
+    return _request('POST', url, headers: headers, body: body, httpClient: httpClient);
   }
 
   /// Performs a PUT request to the specified [url], adding the authorization token.
   ///
   /// If no token already exists, or if it is expired, a new one is requested.
-  Future<http.Response> put(String url,
-      {Map<String, String>? headers,
-      dynamic body,
-      http.Client? httpClient}) async {
-    return _request('PUT', url,
-        headers: headers, body: body, httpClient: httpClient);
+  Future<http.Response> put(String url, {Map<String, String>? headers, dynamic body, http.Client? httpClient}) async {
+    return _request('PUT', url, headers: headers, body: body, httpClient: httpClient);
   }
 
   /// Performs a PATCH request to the specified [url], adding the authorization token.
   ///
   /// If no token already exists, or if it is expired, a new one is requested.
-  Future<http.Response> patch(String url,
-      {Map<String, String>? headers,
-      dynamic body,
-      http.Client? httpClient}) async {
-    return _request('PATCH', url,
-        headers: headers, body: body, httpClient: httpClient);
+  Future<http.Response> patch(String url, {Map<String, String>? headers, dynamic body, http.Client? httpClient}) async {
+    return _request('PATCH', url, headers: headers, body: body, httpClient: httpClient);
   }
 
   /// Performs a GET request to the specified [url], adding the authorization token.
   ///
   /// If no token already exists, or if it is expired, a new one is requested.
-  Future<http.Response> get(String url,
-      {Map<String, String>? headers, http.Client? httpClient}) async {
+  Future<http.Response> get(String url, {Map<String, String>? headers, http.Client? httpClient}) async {
     return _request('GET', url, headers: headers, httpClient: httpClient);
   }
 
   /// Performs a DELETE request to the specified [url], adding the authorization token.
   ///
   /// If no token already exists, or if it is expired, a new one is requested.
-  Future<http.Response> delete(String url,
-      {Map<String, String>? headers, http.Client? httpClient}) async {
+  Future<http.Response> delete(String url, {Map<String, String>? headers, http.Client? httpClient}) async {
     return _request('DELETE', url, headers: headers, httpClient: httpClient);
   }
 
   /// Performs a HEAD request to the specified [url], adding the authorization token.
   ///
   /// If no token already exists, or if it is expired, a new one is requested.
-  Future<http.Response> head(String url,
-      {Map<String, String>? headers,
-      dynamic body,
-      http.Client? httpClient}) async {
+  Future<http.Response> head(String url, {Map<String, String>? headers, dynamic body, http.Client? httpClient}) async {
     return _request('HEAD', url, headers: headers, httpClient: httpClient);
   }
 
   /// Common method for making http requests
   /// Tries to use a previously fetched token, otherwise fetches a new token by means of a refresh flow or by issuing a new authorization flow
   Future<http.Response> _request(String method, String url,
-      {Map<String, String>? headers,
-      dynamic body,
-      http.Client? httpClient}) async {
+      {Map<String, String>? headers, dynamic body, http.Client? httpClient}) async {
     httpClient ??= http.Client();
 
     headers ??= {};
@@ -292,14 +266,11 @@ class OAuth2Helper {
       headers!['Authorization'] = 'Bearer ' + accessToken;
 
       if (method == 'POST') {
-        resp = await httpClient!
-            .post(Uri.parse(url), body: body, headers: headers);
+        resp = await httpClient!.post(Uri.parse(url), body: body, headers: headers);
       } else if (method == 'PUT') {
-        resp =
-            await httpClient!.put(Uri.parse(url), body: body, headers: headers);
+        resp = await httpClient!.put(Uri.parse(url), body: body, headers: headers);
       } else if (method == 'PATCH') {
-        resp = await httpClient!
-            .patch(Uri.parse(url), body: body, headers: headers);
+        resp = await httpClient!.patch(Uri.parse(url), body: body, headers: headers);
       } else if (method == 'GET') {
         resp = await httpClient!.get(Uri.parse(url), headers: headers);
       } else if (method == 'DELETE') {
@@ -343,8 +314,7 @@ class OAuth2Helper {
       throw Exception('Required "clientId" parameter not set');
     }
 
-    if (grantType == CLIENT_CREDENTIALS &&
-        (clientSecret == null || clientSecret!.isEmpty)) {
+    if (grantType == CLIENT_CREDENTIALS && (clientSecret == null || clientSecret!.isEmpty)) {
       throw Exception('Required "clientSecret" parameter not set');
     }
   }


### PR DESCRIPTION
Some oAuth servers might need custom params in authorize url such as MS Azure Active directory. Custom params are supported in other flow types but was missing for `Implicit grant` type.