### PR TITLE
Android storage fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.4.1] - 2022/07/14
+* Fix accessing secure token storage on newer Android versions.
+
 ## [2.4.0] - 2022/05/03
 * Fix for token renewal process through the refresh token flow
 * Expose the TokenStorage class

--- a/lib/src/secure_storage.dart
+++ b/lib/src/secure_storage.dart
@@ -4,7 +4,9 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 BaseStorage createStorage() => SecureStorage();
 
 class SecureStorage implements BaseStorage {
-  static final FlutterSecureStorage storage = FlutterSecureStorage();
+  static final FlutterSecureStorage storage = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
 
   SecureStorage();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: oauth2_client
 
 description: Flutter library for interacting with OAuth2 servers, with classes for transparent authorized requests, secure OAuth token storage, automatic token refeshing.
-version: 2.4.0
+version: 2.4.1
 homepage: https://github.com/teranetsrl/oauth2_client
 repository: https://github.com/teranetsrl/oauth2_client
 environment:


### PR DESCRIPTION
`FlutterSecureStorage` raises an exception on some newer Android OS versions, especially when running on Pixels. Here's an example of exception from Pixel 6 with Android 12 - it's raised when `OAuth2Helper` tries to access the token:

```
Non-fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: PlatformException(Exception encountered, read, javax.crypto.BadPaddingException: error:1e000065:Cipher functions:OPENSSL_internal:BAD_DECRYPT
	at com.android.org.conscrypt.NativeCrypto.EVP_CipherFinal_ex(Native Method)
	at com.android.org.conscrypt.OpenSSLEvpCipher.doFinalInternal(OpenSSLEvpCipher.java:152)
	at com.android.org.conscrypt.OpenSSLCipher.engineDoFinal(OpenSSLCipher.java:374)
	at javax.crypto.Cipher.doFinal(Cipher.java:2055)
	at t6.b.b(Unknown Source:30)
	at s6.d.m(Unknown Source:11)
	at s6.d.t(Unknown Source:10)
	at s6.d.f(Unknown Source:0)
	at s6.d$b.run(Unknown Source:244)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.os.HandlerThread.run(HandlerThread.java:67)
, null). Error thrown null.
       at StandardMethodCodec.decodeEnvelope(message_codecs.dart:607)
       at MethodChannel._invokeMethod(platform_channel.dart:167)
       at SecureStorage.read(secure_storage.dart:14)
       at TokenStorage.getToken(token_storage.dart:25)
       at OAuth2Helper.getTokenFromStorage(oauth2_helper.dart:116)
```

There's a recommended fix under an issue in `flutter_secure_storage` repository, regarding the same problem: https://github.com/mogol/flutter_secure_storage/issues/161#issuecomment-1170370204. This PR applies the fix to `oauth2_client`