### PR TITLE
Fix web popup Oauth 

### DIFF
--- a/lib/src/browser_web_auth.dart
+++ b/lib/src/browser_web_auth.dart
@@ -1,7 +1,10 @@
 import 'base_web_auth.dart';
+import 'dart:async';
 import 'dart:html' as html;
 
 BaseWebAuth createWebAuth() => BrowserWebAuth();
+
+const _oauthRedirect = 'oauth-redirect';
 
 class BrowserWebAuth implements BaseWebAuth {
   @override
@@ -11,16 +14,24 @@ class BrowserWebAuth implements BaseWebAuth {
       required String redirectUrl,
       Map<String, dynamic>? opts}) async {
     // ignore: unsafe_html
-    final popupLogin = html.window.open(
-        url,
-        'oauth2_client::authenticateWindow',
+    html.window.open(url, 'html.window.onMessage',
         'menubar=no, status=no, scrollbars=no, menubar=no, width=1000, height=500');
 
-    var messageEvt = await html.window.onMessage
-        .firstWhere((evt) => evt.origin == Uri.parse(redirectUrl).origin);
+    final completer = Completer<String>();
 
-    popupLogin.close();
+    html.window.onStorage.listen((event) {
+      if (event.key == _oauthRedirect && !completer.isCompleted) {
+        html.window.localStorage.remove(_oauthRedirect);
+        final newValue = event.newValue;
 
-    return messageEvt.data;
+        if (newValue == null) {
+          throw 'oauth-failed';
+        }
+
+        completer.complete(newValue);
+      }
+    });
+
+    return completer.future;
   }
 }


### PR DESCRIPTION
The current implementation of the popup-based web OAuth handoff is broken on browsers that enforce a same-origin COOP policy (cross origin opener policy) since the window.opener value in the spawned popup will be null and the parent's access to the window.closed as described here: https://web.dev/why-coop-coep/#coop. The current implementation in this lib relies  on an onMessage event from the popup which similarly is blocked by COOP.

This means that the opener has no way of knowing when the Oauth redirect has occurred and can not access the code returned from the OAuth handoff in order to finish the flow.

<img width="937" alt="Screen Shot 2022-10-07 at 12 30 02 PM" src="https://user-images.githubusercontent.com/2192930/194602709-5a95a888-8a11-4e65-96ed-7700b8e8e433.png">

This security feature has shipped and is the default behavior in major browsers like Chrome and Firefox as noted here https://bugs.chromium.org/p/chromium/issues/detail?id=1221127 and I've run into this problem firsthand using oauth2_client in Chrome.

I don't have a great fix at this time, the only thing that has worked for me is to use localStorage to pass the code between the popup and the opener but I recognize that storing sensitive data in local storage like the Oauth code is a vulnerability for any malicious JS code that can access it on your domain. I've held off on shipping anything to a production app until I can get a read from folks on if there is a better alternative. 

Let me know what people think, I'm interested in exploring the solutions here further.
Thanks
