### PR TITLE
#111 Added support for the preferEphemeral behavior on android. Requi…

### DIFF
--- a/lib/src/io_web_auth.dart
+++ b/lib/src/io_web_auth.dart
@@ -11,10 +11,11 @@ class IoWebAuth implements BaseWebAuth {
       required String url,
       required String redirectUrl,
       Map<String, dynamic>? opts}) async {
+    final preferEphemeral = (opts?['preferEphemeral'] == true);
+
     return await FlutterWebAuth2.authenticate(
-      callbackUrlScheme: callbackUrlScheme,
-      url: url,
-      preferEphemeral: (opts?['preferEphemeral'] == true),
-    );
+        callbackUrlScheme: callbackUrlScheme,
+        url: url,
+        options: FlutterWebAuth2Options(preferEphemeral: preferEphemeral, intentFlags: ephemeralIntentFlags));
   }
 }

--- a/lib/src/io_web_auth.dart
+++ b/lib/src/io_web_auth.dart
@@ -12,10 +12,12 @@ class IoWebAuth implements BaseWebAuth {
       required String redirectUrl,
       Map<String, dynamic>? opts}) async {
     final preferEphemeral = (opts?['preferEphemeral'] == true);
+    final intentFlags = preferEphemeral ? ephemeralIntentFlags : defaultIntentFlags;
 
     return await FlutterWebAuth2.authenticate(
-        callbackUrlScheme: callbackUrlScheme,
-        url: url,
-        options: FlutterWebAuth2Options(preferEphemeral: preferEphemeral, intentFlags: ephemeralIntentFlags));
+      callbackUrlScheme: callbackUrlScheme,
+      url: url,
+      options: FlutterWebAuth2Options(preferEphemeral: preferEphemeral, intentFlags: intentFlags)
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   crypto: ^3.0.3
   flutter_secure_storage: ^8.0.0
-  flutter_web_auth_2: ^2.2.1
+  flutter_web_auth_2: ^3.1.1
   http: ^1.1.0
   meta: ^1.8.0
   random_string: ^2.3.1


### PR DESCRIPTION
Requires an update to flutter_web_auth_2 3.1.1 as per their docs:
https://pub.dev/packages/flutter_web_auth_2

> preferEphemeral: This has been split into the two named parameters preferEphemeral (for iOS and MacOS) and intentFlags (for Android) within FlutterWebAuth2Options. The former works exactly the same. However, if you want the old behaviour using preferEphemeral on Android, use the ephemeralIntentFlags constant as value for intentFlags.