### PR TITLE
Check for null value before casting scope to String

### DIFF
--- a/lib/src/token_storage.dart
+++ b/lib/src/token_storage.dart
@@ -35,11 +35,11 @@ class TokenStorage {
         var found = false;
 
         if (cleanScopes.isEmpty) {
-          //If the scopes are empty, onlty tokens granted to empty scopes are considered valid...
+          //If the scopes are empty, only tokens granted to empty scopes are considered valid...
           found = (tkn['scope'] == null || tkn['scope'].isEmpty);
         } else {
           //...Otherwise look for a token granted to a superset of the requested scopes
-          if (tkn.containsKey('scope')) {
+          if (tkn.containsKey('scope') && tkn['scope'] != null) {
             final tknCleanScopes = clearScopes(tkn['scope'].cast<String>());
 
             if (tknCleanScopes.isNotEmpty) {


### PR DESCRIPTION
Check for null value, before casting to String. Also fixed typo in comment. This might be a solution for https://github.com/teranetsrl/oauth2_client/issues/64

I'm happy about a review.